### PR TITLE
Make number of filter and SE block adjustable

### DIFF
--- a/quicknat.py
+++ b/quicknat.py
@@ -26,18 +26,18 @@ class QuickNat(nn.Module):
         """
         super(QuickNat, self).__init__()
 
-        self.encode1 = sm.EncoderBlock(params, se_block_type=se.SELayer.CSSE)
-        params['num_channels'] = 64
-        self.encode2 = sm.EncoderBlock(params, se_block_type=se.SELayer.CSSE)
-        self.encode3 = sm.EncoderBlock(params, se_block_type=se.SELayer.CSSE)
-        self.encode4 = sm.EncoderBlock(params, se_block_type=se.SELayer.CSSE)
-        self.bottleneck = sm.DenseBlock(params, se_block_type=se.SELayer.CSSE)
-        params['num_channels'] = 128
-        self.decode1 = sm.DecoderBlock(params, se_block_type=se.SELayer.CSSE)
-        self.decode2 = sm.DecoderBlock(params, se_block_type=se.SELayer.CSSE)
-        self.decode3 = sm.DecoderBlock(params, se_block_type=se.SELayer.CSSE)
-        self.decode4 = sm.DecoderBlock(params, se_block_type=se.SELayer.CSSE)
-        params['num_channels'] = 64
+        self.encode1 = sm.EncoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        params['num_channels'] = params['num_filters']
+        self.encode2 = sm.EncoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        self.encode3 = sm.EncoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        self.encode4 = sm.EncoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        self.bottleneck = sm.DenseBlock(params, se_block_type=se.SELayer(params['se_block']))
+        params['num_channels'] = params['num_filters'] * 2
+        self.decode1 = sm.DecoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        self.decode2 = sm.DecoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        self.decode3 = sm.DecoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        self.decode4 = sm.DecoderBlock(params, se_block_type=se.SELayer(params['se_block']))
+        params['num_channels'] = params['num_filters']
         self.classifier = sm.ClassifierBlock(params)
 
     def forward(self, input):


### PR DESCRIPTION
In the initialization of QuickNat the number of filter as well as the type of S&E is hardcoded. 